### PR TITLE
Remove internal shasta time from genesis hash generation

### DIFF
--- a/deploy-taiko-full.sh
+++ b/deploy-taiko-full.sh
@@ -389,7 +389,6 @@ compute_genesis_hash() {
         --http.vhosts='*' \
         --nodiscover --maxpeers 0 \
         --taiko \
-        --taiko.internal-shasta-time "${TAIKO_INTERNAL_SHASTA_TIME:-0}" \
         >/dev/null 2>&1
 
     log_info "Waiting for taiko-geth RPC (up to 30s)..."


### PR DESCRIPTION
Removed the internal shasta time parameter from the taiko command.